### PR TITLE
Update fish configs: gbc alias and OpenClaw completion

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -13,3 +13,6 @@ end
 starship init fish | source
 set -gx PATH $HOME/.local/bin $PATH
 set -gx PATH "/opt/homebrew/opt/node@22/bin" $PATH
+
+# OpenClaw Completion
+source "/Users/classicus/.openclaw/completions/openclaw.fish"

--- a/fish/functions/gbc.fish
+++ b/fish/functions/gbc.fish
@@ -1,4 +1,3 @@
-function gbc --wraps='git branch -D $(git branch | egrep -v "master")' --wraps='git branch | grep -v master | xargs git branch -D' --description 'alias gbc=git branch | grep -v master | xargs git branch -D'
-  git branch | grep -v master | xargs git branch -D $argv
-        
+function gbc --description 'Delete all local branches except main and master'
+  git branch | grep -v -E 'main|master' | xargs git branch -D $argv
 end


### PR DESCRIPTION
## Summary
- Update `gbc` alias to exclude both `main` and `master` when cleaning local branches
- Add OpenClaw shell completion source to `config.fish`

## Test plan
- [ ] Run `gbc` and verify it preserves both `main` and `master` branches
- [ ] Verify OpenClaw completions load on shell startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)